### PR TITLE
Changed the build configuration to fix SonarScanner not being able to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - fix/SonarScanner-analysis-failing
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
@@ -37,4 +38,4 @@ jobs:
       - name: Build and analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew build sonar --info
+        run: ./gradlew build sonar --info --warning-mode all

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -109,15 +109,16 @@ sonar {
         )
     }
 }
-/*
+
 tasks.withType<Test> {
     useJUnitPlatform()
 }
 
 tasks.withType<Test>().configureEach {
+    jvmArgs = listOf("-XX:+EnableDynamicAgentLoading")
     useJUnitPlatform()
 }
-*/
+
 dependencies {
     implementation(libs.krossbow.websocket.okhttp)
     implementation(libs.krossbow.stomp.core)


### PR DESCRIPTION
# Description
This PR fixes the issue that the SonarScanner fails to build.
___
# Changes
 - Small changes in `build.gradle.kts`
 - Added a flag to `./gradlew build sonar --info --warning-mode all`