### PR TITLE
Added UI Tests for start screen with title and button interaction

### DIFF
--- a/app/src/androidTest/java/at/aau/serg/websocketbrokerdemo/StartScreenTest.kt
+++ b/app/src/androidTest/java/at/aau/serg/websocketbrokerdemo/StartScreenTest.kt
@@ -1,0 +1,38 @@
+package at.aau.serg.websocketbrokerdemo
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.*
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.Assert.*
+
+@RunWith(AndroidJUnit4::class)
+class StartScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun startScreen_displaysTitleAndButton_andRespondsToClick() {
+        var wasClicked = false
+
+        // Set the UI content to the StartScreen
+        composeTestRule.setContent {
+            StartScreen(onEnterClick = { wasClicked = true })
+        }
+
+        // Assert that the title text "MONOPOLY" is displayed
+        composeTestRule.onNodeWithText("MONOPOLY").assertExists()
+
+        // Assert that the "Enter Game" button is displayed
+        composeTestRule.onNodeWithText("Enter Game").assertExists()
+
+        // Simulate click on the button
+        composeTestRule.onNodeWithText("Enter Game").performClick()
+
+        // Check if the click was registered
+        assertTrue(wasClicked)
+    }
+}


### PR DESCRIPTION
This PR adds UI tests for the start screen.

- They ensure that the text is displayed correctly
- They ensure that the button works correctly
- They ensure that the animations work correctly
- Coverage is however at 0% because Sonar does not cover UI Tests