### PR TITLE
Fix secure endpoint and removed unused class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .cxx
 local.properties
 app/google-services.json
+app/src/main/assets/config.properties

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,2 @@
 /build
+/app/src/main/assets/config.properties

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,2 +1,1 @@
 /build
-/app/src/main/assets/config.properties

--- a/app/src/main/assets/config.properties
+++ b/app/src/main/assets/config.properties
@@ -1,1 +1,0 @@
-server.url=ws://10.0.2.2:8080/monopoly

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/MyStomp.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/MyStomp.kt
@@ -1,1 +1,0 @@
-private  val WEBSOCKET_URI = "ws://10.0.2.2:8080/websocket-example-broker";


### PR DESCRIPTION
This pull request addresses a security issue where a property file containing the server endpoint was accidentally committed. 

 Changes:
- Added the property file to .gitignore
- Removed the already committed file from version control
- Deleted an unused class to clean up the codebase

 Reason:
The endpoint should not be versioned for security reasons. This change ensures the file is ignored by Git and doesn't get pushed to any remote repository in the future.

