### PR TITLE
feat: support separate WebSocket URLs for emulator and physical device

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/GameWebSocketClient.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/GameWebSocketClient.kt
@@ -9,7 +9,15 @@ import java.util.Properties
 class GameWebSocketClient(
     private val context: Context,
     private val onConnected: () -> Unit,
-    private val onMessageReceived: (String) -> Unit
+    private val onMessageReceived: (String) -> Unit,
+    private val isEmulatorProvider: () -> Boolean = {
+        val fingerprint = android.os.Build.FINGERPRINT
+        (fingerprint != null && fingerprint.contains("generic")
+                || android.os.Build.MODEL?.contains("Emulator") == true
+                || android.os.Build.MANUFACTURER?.contains("Genymotion") == true
+                || (android.os.Build.BRAND?.startsWith("generic") == true &&
+                android.os.Build.DEVICE?.startsWith("generic") == true))
+    }
 ) {
     private val client = OkHttpClient()
     // Use a nullable WebSocket so we can check if it's already connected
@@ -87,14 +95,13 @@ class GameWebSocketClient(
         webSocket = null
     }
 
-
     private fun loadServerUrl(context: Context): String {
         val properties = Properties()
         context.assets.open("config.properties").use { input ->
             properties.load(input)
         }
 
-        val isEmulator = isEmulator()
+        val isEmulator = isEmulatorProvider()
 
         return if (isEmulator) {
             properties.getProperty("server.url.emulator")
@@ -103,14 +110,6 @@ class GameWebSocketClient(
             properties.getProperty("server.url.device")
                 ?: throw IllegalStateException("Missing device URL in config.properties")
         }
-    }
-
-    private fun isEmulator(): Boolean {
-        val fingerprint = android.os.Build.FINGERPRINT
-        return (fingerprint != null && fingerprint.contains("generic")
-                || android.os.Build.MODEL.contains("Emulator")
-                || android.os.Build.MANUFACTURER.contains("Genymotion")
-                || (android.os.Build.BRAND.startsWith("generic") && android.os.Build.DEVICE.startsWith("generic")))
     }
 
 

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/GameWebSocketClient.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/GameWebSocketClient.kt
@@ -93,6 +93,23 @@ class GameWebSocketClient(
         context.assets.open("config.properties").use { input ->
             properties.load(input)
         }
-        return properties.getProperty("server.url")
+
+        val isEmulator = isEmulator()
+
+        return if (isEmulator) {
+            properties.getProperty("server.url.emulator")
+                ?: throw IllegalStateException("Missing emulator URL in config.properties")
+        } else {
+            properties.getProperty("server.url.device")
+                ?: throw IllegalStateException("Missing device URL in config.properties")
+        }
+    }
+
+    // Hilfsmethode zur Laufzeiterkennung des Emulators
+    private fun isEmulator(): Boolean {
+        return (android.os.Build.FINGERPRINT.contains("generic")
+                || android.os.Build.MODEL.contains("Emulator")
+                || android.os.Build.MANUFACTURER.contains("Genymotion")
+                || (android.os.Build.BRAND.startsWith("generic") && android.os.Build.DEVICE.startsWith("generic")))
     }
 }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/GameWebSocketClient.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/GameWebSocketClient.kt
@@ -105,11 +105,13 @@ class GameWebSocketClient(
         }
     }
 
-    // Hilfsmethode zur Laufzeiterkennung des Emulators
     private fun isEmulator(): Boolean {
-        return (android.os.Build.FINGERPRINT.contains("generic")
+        val fingerprint = android.os.Build.FINGERPRINT
+        return (fingerprint != null && fingerprint.contains("generic")
                 || android.os.Build.MODEL.contains("Emulator")
                 || android.os.Build.MANUFACTURER.contains("Genymotion")
                 || (android.os.Build.BRAND.startsWith("generic") && android.os.Build.DEVICE.startsWith("generic")))
     }
+
+
 }

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/GameWebSocketClientTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/GameWebSocketClientTest.kt
@@ -61,7 +61,8 @@ class GameWebSocketClientTest {
         val client = GameWebSocketClient(
             context,
             onConnected = { onConnectedCalled = true },
-            onMessageReceived = { /* Not needed for this test */ }
+            onMessageReceived = { /* Not needed for this test */ },
+            isEmulatorProvider = { false }
         )
 
 

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/GameWebSocketClientTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/GameWebSocketClientTest.kt
@@ -31,7 +31,7 @@ class GameWebSocketClientTest {
 
     @Test
     fun testLoadServerUrl() {
-        val propertiesContent = "server.url=ws://example.com"
+        val propertiesContent = "server.url.device=ws://example.com"
         val inputStream = ByteArrayInputStream(propertiesContent.toByteArray())
         `when`(assetManager.open("config.properties")).thenReturn(inputStream)
 
@@ -53,7 +53,7 @@ class GameWebSocketClientTest {
     @Test
     fun testSendMessage() {
 
-        val propertiesContent = "server.url=ws://example.com"
+        val propertiesContent = "server.url.device=ws://example.com"
         val inputStream = ByteArrayInputStream(propertiesContent.toByteArray())
         `when`(assetManager.open("config.properties")).thenReturn(inputStream)
 

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/GameWebSocketClientTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/GameWebSocketClientTest.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.AfterEach
 import org.mockito.Mockito.*
 import java.io.ByteArrayInputStream
-import org.junit.jupiter.api.Assertions.*
 
 class GameWebSocketClientTest {
     private lateinit var context: Context


### PR DESCRIPTION
Dieser PR ermöglicht es, dass neben emulierten Android-Geräten auch über USB verbundene Tablets funktionieren.
In der config.properties muss die jeweilige IP-Adresse des PCs, auf dem der Server läuft, eingetragen werden.