### PR TITLE
175 lead leaderboard eigenen status hervorheben

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
@@ -273,8 +273,8 @@ class MainActivity : ComponentActivity() {
             }
             composable("leaderboard") {
                 LeaderboardScreen(
-                    onBack = { navController.popBackStack() }
-                )
+                    onBack = { navController.popBackStack() },
+                    currentUsername = playerProfile?.name)
             }
             composable("settings"){
                 SettingsScreen()

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/LeaderboardScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/LeaderboardScreen.kt
@@ -43,7 +43,7 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun LeaderboardScreen(onBack: () -> Unit) {
+fun LeaderboardScreen(onBack: () -> Unit, currentUsername: String?) {
     val leaderboardTypes = listOf("gamesPlayed", "highestMoney", "level", "averageMoney", "wins")
     var selectedLeaderboard by remember { mutableStateOf(leaderboardTypes[0]) }
     var entries by remember { mutableStateOf<List<Map<String, Any>>>(emptyList()) }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/LeaderboardScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/LeaderboardScreen.kt
@@ -139,7 +139,11 @@ private fun LeaderboardEntryItem(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp),
-        elevation = CardDefaults.cardElevation(2.dp)
+        elevation = CardDefaults.cardElevation(2.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = if (entry["name"] == currentUsername) MaterialTheme.colorScheme.surfaceVariant
+            else MaterialTheme.colorScheme.surface
+        )
     ) {
         Row(
             modifier = Modifier
@@ -149,7 +153,9 @@ private fun LeaderboardEntryItem(
         ) {
             Text(
                 text = "#${entry["rank"]}",
-                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold)
+                style = MaterialTheme.typography.bodyLarge.copy(
+                    fontWeight = if (entry["name"] == currentUsername) FontWeight.Bold else FontWeight.Normal
+                )
             )
             Text(
                 text = entry["name"].toString(),
@@ -159,7 +165,9 @@ private fun LeaderboardEntryItem(
             )
             Text(
                 text = "${entry[selectedLeaderboard]}",
-                style = MaterialTheme.typography.bodyMedium,
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    fontWeight = if (entry["name"] == currentUsername) FontWeight.Bold else FontWeight.Normal
+                ),
                 color = MaterialTheme.colorScheme.secondary
             )
         }

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/LeaderboardScreen.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ui/LeaderboardScreen.kt
@@ -119,7 +119,8 @@ fun LeaderboardScreen(onBack: () -> Unit, currentUsername: String?) {
                     items(entries) { entry ->
                         LeaderboardEntryItem(
                             entry = entry,
-                            selectedLeaderboard = selectedLeaderboard
+                            selectedLeaderboard = selectedLeaderboard,
+                            currentUsername = currentUsername
                         )
                     }
                 }
@@ -131,7 +132,8 @@ fun LeaderboardScreen(onBack: () -> Unit, currentUsername: String?) {
 @Composable
 private fun LeaderboardEntryItem(
     entry: Map<String, Any>,
-    selectedLeaderboard: String
+    selectedLeaderboard: String,
+    currentUsername: String?
 ) {
     Card(
         modifier = Modifier
@@ -151,7 +153,9 @@ private fun LeaderboardEntryItem(
             )
             Text(
                 text = entry["name"].toString(),
-                style = MaterialTheme.typography.bodyLarge
+                style = MaterialTheme.typography.bodyLarge.copy(
+                    fontWeight = if (entry["name"] == currentUsername) FontWeight.Bold else FontWeight.Normal
+                )
             )
             Text(
                 text = "${entry[selectedLeaderboard]}",


### PR DESCRIPTION
Eigener Eintrag in der Tabelle im Leaderboard wird nun als fetter Text hervorgehoben und auch farbig anders als die anderen dargestellt.